### PR TITLE
fix: defensive checks for cwd restore, malloc, and log writes

### DIFF
--- a/atch.c
+++ b/atch.c
@@ -76,11 +76,17 @@ int socket_with_chdir(char *path, int (*fn)(char *))
 	*slash = '\0';
 	s = chdir(path) >= 0 ? fn(slash + 1) : -1;
 	*slash = '/';
-	if (s >= 0 && fchdir(dirfd) < 0) {
-		close(s);
-		s = -1;
+	/* Always restore cwd, regardless of socket operation result */
+	{
+		int saved_errno = errno;
+		if (fchdir(dirfd) < 0) {
+			if (s >= 0) close(s);
+			close(dirfd);
+			return -1;
+		}
+		close(dirfd);
+		errno = saved_errno;
 	}
-	close(dirfd);
 	return s;
 }
 
@@ -275,6 +281,10 @@ static void expand_sockname(void)
 	mkdir(dir, 0700);
 	fulllen = strlen(dir) + 1 + strlen(sockname);
 	full = malloc(fulllen + 1);
+	if (!full) {
+		printf("%s: out of memory\n", progname);
+		exit(1);
+	}
 	snprintf(full, fulllen + 1, "%s/%s", dir, sockname);
 	sockname = full;
 }

--- a/master.c
+++ b/master.c
@@ -58,6 +58,9 @@ static void rotate_log(void)
 	char *buf;
 	ssize_t n;
 
+	if (log_fd < 0)
+		return;
+
 	size = lseek(log_fd, 0, SEEK_END);
 	if (size > (off_t) log_max_size) {
 		buf = malloc(log_max_size);
@@ -70,12 +73,15 @@ static void rotate_log(void)
 				if (write(log_fd, buf, (size_t)n) < 0) {
 					close(log_fd);
 					log_fd = -1;
+					free(buf);
+					return;
 				}
 			}
 			free(buf);
 		}
 	}
-	lseek(log_fd, 0, SEEK_END);
+	if (log_fd >= 0)
+		lseek(log_fd, 0, SEEK_END);
 }
 
 /*
@@ -92,7 +98,7 @@ static int open_log(const char *path)
 
 	log_fd = fd;
 	rotate_log();
-	return fd;
+	return log_fd;
 }
 
 /* Write end marker to log, close it, and unlink the socket. */
@@ -395,6 +401,8 @@ static void pty_activity(int s)
 			close(log_fd);
 			log_fd = -1;
 		}
+	}
+	if (log_fd >= 0) {
 		log_written += (size_t)len;
 		if (log_written >= log_max_size) {
 			rotate_log();

--- a/master.c
+++ b/master.c
@@ -67,7 +67,10 @@ static void rotate_log(void)
 			if (n > 0) {
 				ftruncate(log_fd, 0);
 				lseek(log_fd, 0, SEEK_SET);
-				write(log_fd, buf, (size_t)n);
+				if (write(log_fd, buf, (size_t)n) < 0) {
+					close(log_fd);
+					log_fd = -1;
+				}
 			}
 			free(buf);
 		}
@@ -388,7 +391,10 @@ static void pty_activity(int s)
 	}
 	scrollback_append(buf, (size_t)len);
 	if (log_fd >= 0) {
-		write(log_fd, buf, (size_t)len);
+		if (write(log_fd, buf, (size_t)len) < 0) {
+			close(log_fd);
+			log_fd = -1;
+		}
 		log_written += (size_t)len;
 		if (log_written >= log_max_size) {
 			rotate_log();

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -720,6 +720,21 @@ assert_contains "no args: shows Usage:"              "Usage:" "$out"
 run "$ATCH" --help
 assert_contains "help: shows tail command"           "tail" "$out"
 
+# ── 23. cwd preserved after socket failure ─────────────────────────────────
+# socket_with_chdir must restore cwd even when the socket operation fails.
+# We create the parent dir so chdir succeeds, but the session path is bogus.
+
+ORIG_PWD=$(pwd)
+mkdir -p "$TESTDIR/sockdir"
+"$ATCH" kill "$TESTDIR/sockdir/bogus" >/dev/null 2>&1
+AFTER_PWD=$(pwd)
+if [ "$ORIG_PWD" = "$AFTER_PWD" ]; then
+    ok "cwd: preserved after failed socket operation"
+else
+    fail "cwd: preserved after failed socket operation" "$ORIG_PWD" "$AFTER_PWD"
+    cd "$ORIG_PWD"
+fi
+
 # ── summary ──────────────────────────────────────────────────────────────────
 
 printf "\n1..%d\n" "$T"


### PR DESCRIPTION
## Summary

Three small defensive fixes:

1. **`socket_with_chdir`**: always restore cwd after socket operation, even on failure. Preserves errno so the caller sees the original error.
2. **`expand_sockname`**: check `malloc()` return before use. Exits with error instead of passing NULL to `snprintf` (undefined behavior).
3. **`rotate_log` / `pty_activity`**: once logging is disabled (`log_fd = -1`), no code path touches the fd again. Early guard in `rotate_log()`, split guard blocks in `pty_activity()`, and correct return value from `open_log()`.

## What bugs these fix

- cwd: after a failed socket operation with a long path, the process could remain in the wrong working directory.
- malloc: on OOM, `expand_sockname` would call `snprintf(NULL, ...)` — undefined behavior.
- log: a write failure would close the log fd but subsequent code still incremented `log_written`, called `rotate_log()`, and `lseek()` on the invalid fd.

## Test results

202/203 pass (1 pre-existing: test 93). ASan+UBSan clean.