### PR TITLE
feat: add distro packaging for Arch, Debian, and Gentoo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /atch
 build/
 release/
+*.deb
+*.pkg.tar.*

--- a/makefile
+++ b/makefile
@@ -31,6 +31,14 @@ atch.1: atch.1.md
 
 man: atch.1
 
+PREFIX ?= /usr
+MANDIR ?= $(PREFIX)/share/man
+
+.PHONY: install
+install: atch
+	install -Dm755 $(BUILDDIR)/atch $(DESTDIR)$(PREFIX)/bin/atch
+	if [ -f atch.1 ]; then install -Dm644 atch.1 $(DESTDIR)$(MANDIR)/man1/atch.1; fi
+
 clean:
 	rm -f atch $(OBJ) *.1.md *.c~
 

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -1,0 +1,22 @@
+pkgname=atch
+pkgver=0.4
+pkgrel=1
+pkgdesc='Attach and detach terminal sessions — transparent, no terminal emulation'
+arch=('x86_64' 'aarch64')
+url='https://github.com/mobydeck/atch'
+license=('GPL-2.0-only')
+depends=('glibc')
+makedepends=('gcc' 'pandoc')
+source=("${url}/archive/${pkgver}.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+  cd "$pkgname-$pkgver"
+  make STATIC_FLAG= VERSION="$pkgver"
+  make man
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+  make install DESTDIR="$pkgdir" VERSION="$pkgver"
+}

--- a/pkg/deb/build-deb.sh
+++ b/pkg/deb/build-deb.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+VERSION="${1:?usage: build-deb.sh VERSION}"
+ARCH=$(dpkg --print-architecture)
+PKGDIR="$(mktemp -d)"
+trap 'rm -rf "$PKGDIR"' EXIT
+
+SRCDIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+make -C "$SRCDIR" clean
+make -C "$SRCDIR" VERSION="$VERSION" STATIC_FLAG=
+make -C "$SRCDIR" man
+make -C "$SRCDIR" install DESTDIR="$PKGDIR" VERSION="$VERSION"
+
+mkdir -p "$PKGDIR/DEBIAN"
+cat > "$PKGDIR/DEBIAN/control" <<EOF
+Package: atch
+Version: ${VERSION}
+Section: utils
+Priority: optional
+Architecture: ${ARCH}
+Depends: libc6
+Maintainer: mobydeck <noreply@github.com>
+Homepage: https://github.com/mobydeck/atch
+Description: Attach and detach terminal sessions
+ Transparent terminal session manager with persistent
+ session history and multi-client attach support.
+EOF
+
+dpkg-deb --build "$PKGDIR" "${SRCDIR}/atch_${VERSION}_${ARCH}.deb"
+echo "Built: atch_${VERSION}_${ARCH}.deb"

--- a/pkg/gentoo/app-misc/atch/atch-9999.ebuild
+++ b/pkg/gentoo/app-misc/atch/atch-9999.ebuild
@@ -1,0 +1,32 @@
+# Copyright 2024-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Attach and detach terminal sessions — transparent, no terminal emulation"
+HOMEPAGE="https://github.com/mobydeck/atch"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/mobydeck/atch.git"
+else
+	SRC_URI="https://github.com/mobydeck/atch/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	S="${WORKDIR}/${P}"
+	KEYWORDS="~amd64 ~arm64"
+fi
+
+LICENSE="GPL-2"
+SLOT="0"
+
+DEPEND="sys-libs/glibc"
+BDEPEND="app-text/pandoc"
+
+src_compile() {
+	emake STATIC_FLAG= VERSION="${PV}"
+	emake man
+}
+
+src_install() {
+	emake install DESTDIR="${D}" VERSION="${PV}"
+	dodoc README.md
+}


### PR DESCRIPTION
## Summary

- Add `make install` target with `DESTDIR`/`PREFIX` support (required by all packaging systems)
- Add `pkg/arch/PKGBUILD` — Arch Linux package, buildable with `makepkg -si`
- Add `pkg/deb/build-deb.sh` — self-contained script to produce a `.deb` package
- Add `pkg/gentoo/` ebuild for Gentoo overlays (supports both live `9999` and versioned builds)

All three packages build with dynamic linking (`STATIC_FLAG=`) per distro conventions. Release tarballs remain statically linked as before.

## Test plan

- [x] `make install DESTDIR=/tmp/test` installs binary and man page correctly
- [ ] `cd pkg/arch && makepkg -si` builds and installs on Arch
- [ ] `./pkg/deb/build-deb.sh 0.4` produces a valid .deb on Debian/Ubuntu
- [ ] Gentoo ebuild works in a local overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)