### PR TITLE
security: harden session directory, stale-socket unlink, and clear path

### DIFF
--- a/atch.c
+++ b/atch.c
@@ -569,6 +569,7 @@ static int cmd_clear(int argc, char **argv)
 	} else {
 		const char *chain = getenv(SESSION_ENVVAR);
 		const char *last;
+		char *copy;
 
 		if (!chain || !*chain) {
 			printf("%s: No session was specified.\n", progname);
@@ -577,7 +578,13 @@ static int cmd_clear(int argc, char **argv)
 			return 1;
 		}
 		last = strrchr(chain, ':');
-		sockname = (char *)(last ? last + 1 : chain);
+		/* getenv() returns a pointer into the environment block; sockname
+		** is char* and other code paths assume it's owned writable storage.
+		** Duplicate so we never cast away const or risk mutating env. */
+		copy = strdup(last ? last + 1 : chain);
+		if (!copy)
+			return 1;
+		sockname = copy;
 	}
 	if (argc > 0) {
 		printf("%s: Invalid number of arguments.\n", progname);
@@ -585,7 +592,10 @@ static int cmd_clear(int argc, char **argv)
 		return 1;
 	}
 	snprintf(log_path, sizeof(log_path), "%s.log", sockname);
-	fd = open(log_path, O_WRONLY | O_TRUNC);
+	/* O_NOFOLLOW: refuse to truncate via a symlink. Without it, anyone
+	** who can plant a symlink at <sockname>.log can redirect this truncate
+	** onto an arbitrary user-writable file. */
+	fd = open(log_path, O_WRONLY | O_TRUNC | O_NOFOLLOW);
 	if (fd >= 0) {
 		close(fd);
 		if (!quiet)

--- a/atch.c
+++ b/atch.c
@@ -254,6 +254,36 @@ static int parse_options(int *argc, char ***argv)
 	return 0;
 }
 
+/* Verify dir is a real directory owned by us with mode 0700. Refuse if not:
+** an attacker who pre-creates /tmp/.atch-<uid>/ (or any session dir) with
+** weaker modes or as a symlink could trick us into writing sockets and logs
+** under their control. lstat ensures we don't follow a symlink. */
+static int ensure_safe_dir(const char *path)
+{
+	struct stat st;
+
+	if (lstat(path, &st) < 0) {
+		printf("%s: %s: %s\n", progname, path, strerror(errno));
+		return 1;
+	}
+	if (!S_ISDIR(st.st_mode)) {
+		printf("%s: %s: not a directory\n", progname, path);
+		return 1;
+	}
+	if (st.st_uid != getuid()) {
+		printf("%s: %s: refusing to use directory not owned by uid %d\n",
+		       progname, path, (int)getuid());
+		return 1;
+	}
+	if ((st.st_mode & 077) != 0) {
+		printf("%s: %s: refusing to use directory with mode %04o "
+		       "(must be 0700)\n",
+		       progname, path, (unsigned)(st.st_mode & 07777));
+		return 1;
+	}
+	return 0;
+}
+
 /* Expand a bare session name to its full socket path in-place. */
 static void expand_sockname(void)
 {
@@ -273,6 +303,8 @@ static void expand_sockname(void)
 		*slash = '/';
 	}
 	mkdir(dir, 0700);
+	if (ensure_safe_dir(dir))
+		exit(1);
 	fulllen = strlen(dir) + 1 + strlen(sockname);
 	full = malloc(fulllen + 1);
 	snprintf(full, fulllen + 1, "%s/%s", dir, sockname);

--- a/atch.c
+++ b/atch.c
@@ -254,6 +254,23 @@ static int parse_options(int *argc, char ***argv)
 	return 0;
 }
 
+/* lstat the socket path and unlink only if it really is a unix socket owned
+** by the current user. Without this check, a race between connect() failing
+** with ECONNREFUSED and the unlink lets an attacker who controls the session
+** directory swap in a symlink and have us delete an arbitrary file. */
+static void safe_unlink_socket(const char *path)
+{
+	struct stat st;
+
+	if (lstat(path, &st) < 0)
+		return;
+	if (!S_ISSOCK(st.st_mode))
+		return;
+	if (st.st_uid != getuid())
+		return;
+	unlink(path);
+}
+
 /* Verify dir is a real directory owned by us with mode 0700. Refuse if not:
 ** an attacker who pre-creates /tmp/.atch-<uid>/ (or any session dir) with
 ** weaker modes or as a symlink could trick us into writing sockets and logs
@@ -738,7 +755,7 @@ static int cmd_open(char *session, int argc, char **argv)
 
 			replay_session_log(saved_errno);
 			if (saved_errno == ECONNREFUSED)
-				unlink(sockname);
+				safe_unlink_socket(sockname);
 			if (master_main(argv, 1, 0) != 0)
 				return 1;
 			if (!quiet)
@@ -933,7 +950,7 @@ int main(int argc, char **argv)
 
 				replay_session_log(saved_errno);
 				if (saved_errno == ECONNREFUSED)
-					unlink(sockname);
+					safe_unlink_socket(sockname);
 				if (master_main(argv, 1, 0) != 0)
 					return 1;
 			}

--- a/master.c
+++ b/master.c
@@ -83,7 +83,11 @@ static int open_log(const char *path)
 {
 	int fd;
 
-	fd = open(path, O_RDWR | O_CREAT, 0600);
+	/* O_NOFOLLOW: refuse to open if the log path is a symlink. Combined
+	** with the session-dir uid/mode check, this stops an attacker who
+	** controls the session directory from redirecting the log into an
+	** arbitrary file via a pre-placed symlink. */
+	fd = open(path, O_RDWR | O_CREAT | O_NOFOLLOW, 0600);
 	if (fd < 0)
 		return -1;
 


### PR DESCRIPTION
Three related local-attack hardenings, one per commit. Each is independent and small enough to revert in isolation.

## 1. Validate session directory ownership and mode

`expand_sockname()` calls `mkdir(dir, 0700)` and ignores the return value. On the `/tmp/.<progname>-<uid>` fallback path (taken when `\$HOME` is unset or `/`), a hostile local user can pre-create that directory with permissive modes (or as a symlink) before the victim runs atch — every subsequent socket and `.log` lands under attacker control.

Fix: after `mkdir`, `lstat` the directory and refuse to proceed unless it is a real directory (not a symlink) owned by the current uid with mode `0700`.

Also adds `O_NOFOLLOW` to the master's session-log open. Defense in depth: with the directory check in place the dir contents are already user-only, but `O_NOFOLLOW` also blocks any same-uid process that plants a symlink between `mkdir` and `open`.

## 2. Stat before unlinking stale session socket

`cmd_open` and the legacy `-A` mode call `unlink(sockname)` unconditionally when `connect()` returns `ECONNREFUSED`. With the directory check this is no longer cross-user-reachable, but the TOCTOU between the failed connect and the unlink is still a sharp edge.

Fix: `lstat` the path and unlink only if it's really a unix socket owned by the current uid.

## 3. Copy session name from env in `cmd_clear`, `O_NOFOLLOW` the log

`cmd_clear` stored a `const char *` returned by `getenv()` into the global `char *sockname` via a cast that drops `const` — undefined behavior if any future code path mutates `sockname`. Duplicate the chosen ancestry segment into owned storage instead.

Open the log with `O_NOFOLLOW` for the same reason as commit 1: refuse to truncate via a symlink.

## Test plan

- [x] `make` clean (no new warnings)
- [x] `sh tests/test.sh ./atch` — 228/229 (the one failing test fails on `main` too; unrelated)
- [x] Manual negative tests pass:
  - Pre-create `~/.cache/atch` mode 0755 → atch refuses with clear message
  - Plant `~/.cache/atch/x.log` → `/tmp/target` symlink, run `atch clear x` → refused (`ELOOP`), target untouched
  - Plant `~/.cache/atch/x.log` → `/tmp/target` symlink, run `atch start x …` → log open silently disabled (existing best-effort behavior), target untouched

## Notes

- No new dependencies, no behavior change for the normal `\$HOME/.cache/<progname>/` path with default mode `0700`.
- Existing setups with a wider mode on the session dir will start refusing — that's the intended security boundary, but worth calling out for downstream packagers.
- Three other findings from the same audit (arbitrary signal via `MSG_KILL`, raw escape replay on attach/tail, `tail -f` blind to log rotation) are not included here; happy to send follow-up PRs if you want them.