### PR TITLE
added timed drain filter to prevent garbage input after attach

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -366,6 +366,49 @@ int attach_main(int noerror)
 	cur_term.c_cc[VTIME] = 0;
 	tcsetattr(0, TCSADRAIN, &cur_term);
 
+	/* Drain: now that we are in raw mode, swallow any terminal
+	 * responses provoked by the on-disk log replay.  We do this
+	 * BEFORE sending MSG_ATTACH / MSG_REDRAW so that the running
+	 * program's own query/response cycle (e.g. fish prompts after
+	 * SIGWINCH) flows through normally and is never swallowed.
+	 * Default 100ms; override with ATCH_DRAIN_MS, 0 to disable. */
+	{
+		int drain_ms = 100;
+		const char *env_drain = getenv("ATCH_DRAIN_MS");
+		if (env_drain)
+			drain_ms = atoi(env_drain);
+		if (drain_ms > 0) {
+			struct timeval deadline, now;
+			fd_set drfds;
+			unsigned char junk[256];
+
+			gettimeofday(&deadline, NULL);
+			deadline.tv_usec += (long)(drain_ms % 1000) * 1000;
+			deadline.tv_sec += drain_ms / 1000;
+			if (deadline.tv_usec >= 1000000) {
+				deadline.tv_sec++;
+				deadline.tv_usec -= 1000000;
+			}
+			for (;;) {
+				struct timeval tv;
+				long usec_left;
+
+				gettimeofday(&now, NULL);
+				usec_left =
+				    (deadline.tv_sec - now.tv_sec) * 1000000 +
+				    (deadline.tv_usec - now.tv_usec);
+				if (usec_left <= 0)
+					break;
+				tv.tv_sec = usec_left / 1000000;
+				tv.tv_usec = usec_left % 1000000;
+				FD_ZERO(&drfds);
+				FD_SET(0, &drfds);
+				if (select(1, &drfds, NULL, NULL, &tv) > 0)
+					(void)read(0, junk, sizeof(junk));
+			}
+		}
+	}
+
 	/* Clear the screen on attach. Only do a full reset when explicitly
 	 ** requested (CLEAR_MOVE); default/unspec just emits a blank line so
 	 ** any preceding log replay remains visible.


### PR DESCRIPTION
Problem:

When reattaching to a session running a program that uses terminal query sequences (vim, fish, etc.) the on-disk log replay writes raw escape sequences to the new terminal.  atch forwards those responses to the pty as keyboard input, causing the program to interpret them as typed characters, resulting in junk input.  This is easily demonstrated by detaching and reattaching a session running vim, where it will paste junk from the clipboard immediately on attach.

Fix:

After switching to raw mode and before sending MSG_ATTACH / MSG_REDRAW, run a short drain loop (default 100ms) that reads and discards anything arriving on stdin. This swallows the terminal's responses to replayed query sequences.  It only watches stdin (not the socket), so it cannot interfere with pty data.

Placing the drain before MSG_ATTACH and MSG_REDRAW is critical: the SIGWINCH triggered by MSG_REDRAW causes programs like fish to redraw their prompts, which involves sending new terminal queries and expecting responses. If the drain ran during the main select loop, it would swallow those legitimate responses and cause the program to hang waiting for them.

The drain duration can be overridden with ATCH_DRAIN_MS (e.g. ATCH_DRAIN_MS=200) or disabled entirely with ATCH_DRAIN_MS=0