### PR TITLE
Allow setting default session directory via environment variable

### DIFF
--- a/atch.c
+++ b/atch.c
@@ -36,9 +36,16 @@ const char *session_shortname(void)
 /* Returns the directory where session sockets are stored. */
 void get_session_dir(char *buf, size_t size)
 {
+	const char *dir_env = getenv("ATCH_SESSION_DIR");
 	const char *home = getenv("HOME");
 	const char *base = strrchr(progname, '/');
 	struct passwd *pw;
+
+	/* Allow override via ATCH_SESSION_DIR environment variable. */
+	if (dir_env && *dir_env) {
+		snprintf(buf, size, "%s", dir_env);
+		return;
+	}
 
 	base = base ? base + 1 : progname;
 


### PR DESCRIPTION
# Background

The session directory is always computed from `$HOME` (`~/.cache/atch/`). This will be problematic when:

- **Containers share a home directory bind mount** — multiple containers clobber each other's sockets and logs.
- **NFS-mounted centralised home** — machines on the network see stale sockets from other hosts, causing connection failures or phantom sessions.

# Solution

I'm adding `ATCH_SESSION_DIR` environment variable at `get_session_dir()` to allow user to override the default session directory location.